### PR TITLE
feat: HPF in playback pipeline for speaker protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.0] - 2026-02-14
+
+### Added: High-Pass Filter (HPF) in Playback Pipeline (Issue #2)
+
+Speaker protection HPF stage inserted in the playback signal chain between PCM
+and Gain widgets. Reduces low-frequency excursion and distortion on small laptop
+speakers.
+
+### Added
+
+- **HPF widget in playback topology** - New `HPF1.0` widget (type EFFECT,
+  module SST_MOD_HPF) inserted between `pcm0p` and `PGA1.0` in the default
+  Broadwell-U playback pipeline: `PCM -> HPF -> Gain -> SSP0 DAI OUT`
+- **Precomputed 2nd-order Butterworth biquad coefficients** at 48kHz -
+  9 presets (bypass + 80/100/120/150/180/200/250/300 Hz) in Q2.30 fixed-point.
+  Mathematically verified against the standard Butterworth formula.
+- **IPC biquad command** - `sst_ipc_set_biquad()` sends Q2.30 coefficients
+  for left and right channels via `SST_IPC_STG_SET_BIQUAD` stage message.
+- **Mixer BASS control** - HPF cutoff exposed as `SOUND_MIXER_BASS` in
+  the OSS mixer. Value 0 = bypass, 1-100 maps across 80-300 Hz presets.
+  Default: 150 Hz (mixer bass = 50).
+- **Runtime HPF update** - `sst_topology_set_widget_hpf()` finds closest
+  preset and sends biquad coefficients to DSP if stream is active.
+
+### Changed
+
+- Playback pipeline route: `pcm0p -> HPF1.0 -> PGA1.0 -> ssp0` (was `pcm0p -> PGA1.0 -> ssp0`)
+- Playback pipeline now has 4 widgets (was 3)
+- Route count increased by 1 (HPF1.0 -> PGA1.0 added)
+
+---
+
 ## [0.52.0] - 2026-02-14
 
 ### MILESTONE: First Audio Output!
@@ -871,7 +903,8 @@ IRQ allocation, IPC init, firmware load (IntcSST2.bin), DMA/SSP/PCM/topology ini
 - `Fixed` for any bug fixes
 - `Security` for vulnerability fixes
 
-[Unreleased]: https://github.com/spagu/acpi_intel_sst/compare/v0.53.0...HEAD
+[Unreleased]: https://github.com/spagu/acpi_intel_sst/compare/v0.54.0...HEAD
+[0.54.0]: https://github.com/spagu/acpi_intel_sst/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/spagu/acpi_intel_sst/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/spagu/acpi_intel_sst/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/spagu/acpi_intel_sst/compare/v0.50.0...v0.51.0

--- a/DIAGRAMS.md
+++ b/DIAGRAMS.md
@@ -11,7 +11,8 @@ graph TD
     A["Application (play, mpv, firefox...)"] --> B["/dev/dsp — sound(4)"]
     B --> C["acpi_intel_sst.ko"]
     C -->|"IPC (catpt)"| D["DSP Firmware (IntcSST2.bin)"]
-    D -->|"DMA"| E["SSP0 — I2S 48kHz stereo"]
+    D -->|"HPF + Gain"| D2["DSP Pipeline"]
+    D2 -->|"DMA"| E["SSP0 — I2S 48kHz stereo"]
     E --> F["RT286 / ALC3263 codec (I2C0)"]
     F --> G["Speakers / Headphones"]
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ graph TD
     A["Application (play, mpv, firefox...)"] --> B["/dev/dsp — sound(4)"]
     B --> C["acpi_intel_sst.ko"]
     C -->|"IPC (catpt)"| D["DSP Firmware (IntcSST2.bin)"]
-    D -->|"DMA"| E["SSP0 — I2S 48kHz stereo"]
+    D -->|"HPF + Gain"| D2["DSP Pipeline"]
+    D2 -->|"DMA"| E["SSP0 — I2S 48kHz stereo"]
     E --> F["RT286 / ALC3263 codec (I2C0)"]
     F --> G["Speakers / Headphones"]
 
@@ -262,7 +263,7 @@ These devices use the same Intel SST DSP and may work (untested):
 | [`sst_ssp.c`](sst_ssp.c) | I2S/SSP port configuration (2 ports) |
 | [`sst_dma.c`](sst_dma.c) | DMA controller (DesignWare DW-DMAC, 8 channels) |
 | [`sst_jack.c`](sst_jack.c) | Headphone jack detection (GPIO polling, debounce) |
-| [`sst_topology.c`](sst_topology.c) | Audio pipeline configuration (default Broadwell-U topology) |
+| [`sst_topology.c`](sst_topology.c) | Audio pipeline configuration (default Broadwell-U topology, HPF biquad) |
 | [`sst_regs.h`](sst_regs.h) | Hardware register definitions (SHIM, VDRTCTL, SSP, DMA) |
 
 ---
@@ -272,7 +273,7 @@ These devices use the same Intel SST DSP and may work (untested):
 | Issue | Details |
 |:------|:--------|
 | **Capture disabled** | Channels registered but skipped; DSP can't do simultaneous play+capture on same SSP |
-| **No volume via IPC** | Mixer widget exists but changes don't reach DSP firmware |
+| **Volume via IPC partial** | Gain widget exists; HPF (bass) control sends biquad coefficients to DSP |
 | **No suspend/resume** | Driver doesn't handle D3 transitions during sleep |
 | **Single platform tested** | Only Dell XPS 13 9343; other Broadwell-U/Haswell untested |
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Intel SST Audio Driver - Session Status
 ## Date: 2026-02-14
-## Version: v0.52.0
+## Version: v0.54.0
 
 ---
 
@@ -98,7 +98,7 @@ sound(4)  ←→  pcm child device (PCM_SOFTC_SIZE softc)
 | sst_dma.c | DMA controller | Working |
 | sst_pcm.c | sound(4) integration | 90% |
 | sst_ssp.c | I2S codec interface | Working |
-| sst_topology.c | Audio pipeline | Stub |
+| sst_topology.c | Audio pipeline + HPF biquad | Working |
 | sst_jack.c | Headphone detect | Working |
 | sst_regs.h | Register definitions | Done |
 
@@ -130,6 +130,7 @@ sound(4)  ←→  pcm child device (PCM_SOFTC_SIZE softc)
 
 ## COMMIT HISTORY
 ```
+v0.54.0 - HPF in playback pipeline, biquad IPC, BASS mixer control (issue #2)
 v0.52.0 - First audio output! Fix NID shift, channel map, I2C, ISR debug
 v0.51.0 - fix NID shift in codec verbs (<<20 -> <<24) + disable capture stream
 v0.50.0 - fix playback - SYSTEM stream type, catpt IPC sequence, codec I2S mode

--- a/sst_ipc.h
+++ b/sst_ipc.h
@@ -45,6 +45,7 @@
 #define SST_IPC_STG_SET_VOLUME		1
 #define SST_IPC_STG_SET_WRITE_POS	2
 #define SST_IPC_STG_MUTE_LOOPBACK	3
+#define SST_IPC_STG_SET_BIQUAD		4
 
 /*
  * Notification Types (from DSP)
@@ -444,6 +445,11 @@ int	sst_ipc_set_write_pos(struct sst_softc *sc, uint32_t stream_id,
 /* Mixer control */
 int	sst_ipc_set_mixer(struct sst_softc *sc, struct sst_mixer_params *params);
 int	sst_ipc_get_mixer(struct sst_softc *sc, struct sst_mixer_params *params);
+
+/* Biquad filter */
+int	sst_ipc_set_biquad(struct sst_softc *sc, uint32_t stream_id,
+			   int32_t b0, int32_t b1, int32_t b2,
+			   int32_t a1, int32_t a2);
 
 /* Power management */
 int	sst_ipc_set_dx(struct sst_softc *sc, uint32_t state);

--- a/sst_pcm.h
+++ b/sst_pcm.h
@@ -125,6 +125,9 @@ struct sst_pcm {
 	int			vol_right;	/* Right volume (0-100) */
 	int			mute;		/* Mute state */
 
+	/* HPF control */
+	uint32_t		hpf_cutoff;	/* HPF cutoff in Hz, 0=bypass */
+
 	/* State */
 	bool			registered;	/* PCM device registered */
 };

--- a/sst_topology.h
+++ b/sst_topology.h
@@ -81,6 +81,7 @@ enum sst_module_type {
 	SST_MOD_SRC,			/* Sample rate converter */
 	SST_MOD_EQ,			/* Equalizer */
 	SST_MOD_DRC,			/* Dynamic range compressor */
+	SST_MOD_HPF,			/* High-pass filter */
 	SST_MOD_MAX
 };
 
@@ -107,6 +108,9 @@ struct sst_widget {
 	/* Volume control (for PGA/MIXER) */
 	int32_t			volume;		/* -64dB to +20dB in 0.5dB steps */
 	bool			mute;
+
+	/* HPF control (for EFFECT/HPF) */
+	uint32_t		hpf_cutoff;	/* HPF cutoff in Hz, 0=bypass */
 
 	/* Linked list */
 	struct sst_widget	*next;
@@ -235,6 +239,8 @@ struct sst_widget *sst_topology_find_widget(struct sst_softc *sc,
 					    const char *name);
 int	sst_topology_set_widget_volume(struct sst_softc *sc,
 				       struct sst_widget *w, int32_t volume);
+int	sst_topology_set_widget_hpf(struct sst_softc *sc,
+				    struct sst_widget *w, uint32_t cutoff);
 
 /* Route management */
 int	sst_topology_connect_route(struct sst_softc *sc, struct sst_route *r);


### PR DESCRIPTION
## Summary

Implements GitHub issue #2 — High-Pass Filter (HPF) in the playback pipeline.

- Inserts a configurable 2nd-order Butterworth HPF between PCM and Gain widgets in the default Broadwell-U playback topology
- 9 frequency presets: bypass + 80/100/120/150/180/200/250/300 Hz, precomputed as Q2.30 biquad coefficients at 48kHz
- Exposes HPF cutoff as `SOUND_MIXER_BASS` control (0=bypass, 1-100 → 80-300 Hz), default 150 Hz
- Runtime DSP update via new `SST_IPC_STG_SET_BIQUAD` IPC stage message

### Files changed (10)

| File | Change |
|------|--------|
| `sst_topology.c` | HPF widget, biquad table, `sst_topology_set_widget_hpf()`, updated routes |
| `sst_topology.h` | `SST_MOD_HPF` enum, `hpf_cutoff` field, function prototype |
| `sst_ipc.c` | `sst_ipc_set_biquad()` — sends Q2.30 coefficients per channel |
| `sst_ipc.h` | `SST_IPC_STG_SET_BIQUAD` define, function prototype |
| `sst_pcm.c` | `SOUND_MIXER_BASS` handler, HPF cutoff table, mixer init |
| `sst_pcm.h` | `hpf_cutoff` field in `struct sst_pcm` |
| `CHANGELOG.md` | v0.54.0 entry |
| `README.md` | Updated pipeline diagram and known issues |
| `DIAGRAMS.md` | Updated pipeline diagram |
| `STATUS.md` | Updated version, topology status |

### Biquad coefficient verification

All 8 non-bypass entries verified mathematically (Python):
- `b0 == b2` holds exactly (Butterworth symmetry)
- `b1 == -2*b0` within ±1 LSB (independent Q2.30 rounding)
- All coefficients match formula-derived values with **zero delta**

### Pipeline change

```
Before:  PCM → Gain → SSP0 DAI OUT → Codec
After:   PCM → HPF → Gain → SSP0 DAI OUT → Codec
```

## Test plan

- [x] Kernel module compiles cleanly with `-Werror` (FreeBSD 15-CURRENT)
- [x] Biquad coefficients mathematically verified against Butterworth formula
- [x] Verify `mixer bass 50` sets 150 Hz cutoff (dmesg / sysctl)
- [x] Verify `mixer bass 0` bypasses HPF (unity passthrough)
- [x] Audio playback with HPF enabled — no new distortion artifacts
- [x] Verify HPF reduces low-frequency content (compare spectrograms)

Closes #2