### PR TITLE
fix: remove spurious SET_MIXER_PARAMS IPC from volume path

### DIFF
--- a/sst_pcm.c
+++ b/sst_pcm.c
@@ -1067,7 +1067,6 @@ static int
 sst_mixer_set(struct snd_mixer *m, unsigned dev, unsigned left, unsigned right)
 {
 	struct sst_softc *sc = mix_getdevinfo(m);
-	struct sst_mixer_params params;
 	struct sst_stream_params sp;
 	int i;
 
@@ -1076,15 +1075,6 @@ sst_mixer_set(struct snd_mixer *m, unsigned dev, unsigned left, unsigned right)
 	case SOUND_MIXER_PCM:
 		sc->pcm.vol_left = left;
 		sc->pcm.vol_right = right;
-
-		/* Update DSP master mixer if firmware running */
-		if (sc->fw.state == SST_FW_STATE_RUNNING) {
-			memset(&params, 0, sizeof(params));
-			params.output_id = 0;	/* Main output */
-			params.volume = (left + right) / 2;
-			params.mute = sc->pcm.mute;
-			sst_ipc_set_mixer(sc, &params);
-		}
 
 		/* Update volume on all active playback streams */
 		for (i = 0; i < SST_PCM_MAX_PLAY; i++) {


### PR DESCRIPTION
## Summary
- Remove unnecessary `sst_ipc_set_mixer()` call from the mixer volume handler
- The catpt firmware type 13 (`GET_MIXER_STREAM_INFO`) is GET-only — the DSP has no SET variant
- The call was sending a raw percentage (0-100) in a field the DSP ignores, adding one unnecessary IPC round-trip per volume change
- Volume is already controlled correctly via per-stream `SET_VOLUME` with Q1.31 gain values

## Test plan
- [x] `make clean && make` builds with no warnings under `-Werror`
- [ ] Load module, play audio, adjust volume — verify one fewer IPC message per change in dmesg