### PR TITLE
feat: improve suspend/resume stability

### DIFF
--- a/sst_firmware.h
+++ b/sst_firmware.h
@@ -133,6 +133,7 @@ void	sst_fw_fini(struct sst_softc *sc);
 int	sst_fw_load(struct sst_softc *sc);
 void	sst_fw_unload(struct sst_softc *sc);
 int	sst_fw_boot(struct sst_softc *sc);
+int	sst_fw_reload(struct sst_softc *sc);
 void	sst_fw_alloc_module_regions(struct sst_softc *sc);
 
 #endif /* _SST_FIRMWARE_H_ */

--- a/sst_pcm.h
+++ b/sst_pcm.h
@@ -136,6 +136,11 @@ struct sst_pcm {
 	int			vol_ticks;	/* tick count of last SET_VOLUME */
 	bool			vol_pending;	/* deferred volume update waiting */
 
+	/* Resume state */
+	bool			resume_ramp;	/* Volume ramp-in pending after resume */
+	int			ramp_step;	/* Current ramp step (0-5) */
+	struct callout		ramp_callout;	/* Ramp timer */
+
 	/* State */
 	bool			registered;	/* PCM device registered */
 };
@@ -148,6 +153,8 @@ struct sst_softc;
  */
 int	sst_pcm_init(struct sst_softc *sc);
 void	sst_pcm_fini(struct sst_softc *sc);
+void	sst_pcm_suspend(struct sst_softc *sc);
+void	sst_pcm_resume(struct sst_softc *sc);
 int	sst_pcm_register(struct sst_softc *sc);
 void	sst_pcm_unregister(struct sst_softc *sc);
 


### PR DESCRIPTION
## Summary
- Full subsystem teardown on suspend: jack polling, PCM streams, SSP ports, codec, and topology are all properly shut down before DSP reset and D3 power-off
- Complete audio pipeline reconstruction on resume: firmware reloaded to SRAM from cached host memory, DSP booted, topology rebuilt, SSP0 configured, codec re-initialized, mixer state restored, jack detection restarted
- 5-step volume ramp-in (~50ms) on first playback after resume to prevent pop noise
- Mixer parameters (volume, HPF, limiter) now applied on every PCMTRIG_START, also fixing parameter loss after stall recovery

## Files Changed
| File | Change |
|------|--------|
| `sst_firmware.c` | Add `sst_fw_reload()` — re-writes cached firmware to SRAM |
| `sst_firmware.h` | Add `sst_fw_reload()` prototype |
| `acpi_intel_sst.c` | Rewrite `sst_acpi_suspend()` and `sst_acpi_resume()` |
| `sst_pcm.c` | Add `sst_pcm_suspend()`/`sst_pcm_resume()`, ramp callout, mixer restore on stream start |
| `sst_pcm.h` | Add `resume_ramp`/`ramp_step`/`ramp_callout` fields, suspend/resume prototypes |

## Test plan
- [ ] `make clean && make` compiles with no new warnings
- [ ] `kldload`, play audio — verify working baseline
- [ ] `acpiconf -s 3`, resume — check dmesg for full suspend/resume sequence
- [ ] Post-resume playback — should play without pop
- [ ] `mixer vol` before and after suspend — same values
- [ ] Suspend/resume 3 times, play each time — stable across cycles

Closes #10