### PR TITLE
feat: parametric EQ presets via BASS mixer

### DIFF
--- a/sst_pcm.c
+++ b/sst_pcm.c
@@ -843,6 +843,17 @@ sst_pcm_poll(void *arg)
 				sst_ipc_stream_set_params(sc, &vsp);
 			}
 
+			/* Restore EQ preset */
+			{
+				struct sst_widget *hpf_w;
+				hpf_w = sst_topology_find_widget(sc, "HPF1.0");
+				if (hpf_w != NULL) {
+					hpf_w->stream_id = ch->stream_id;
+					sst_topology_set_widget_eq_preset(sc,
+					    hpf_w, sc->pcm.eq_preset);
+				}
+			}
+
 			device_printf(sc->dev,
 			    "PCM: stream recovered as %u\n",
 			    ch->stream_id);
@@ -963,10 +974,10 @@ sst_pcm_resume(struct sst_softc *sc)
 {
 	struct sst_widget *w;
 
-	/* Restore HPF cutoff to widget */
+	/* Restore EQ preset to widget */
 	w = sst_topology_find_widget(sc, "HPF1.0");
 	if (w != NULL)
-		w->hpf_cutoff = sc->pcm.hpf_cutoff;
+		w->eq_preset = sc->pcm.eq_preset;
 
 	/* Restore limiter threshold to widget */
 	w = sst_topology_find_widget(sc, "LIMITER1.0");
@@ -1105,15 +1116,15 @@ sst_chan_trigger(kobj_t obj, void *data, int go)
 			sst_ipc_stream_set_params(sc, &sp);
 		}
 
-		/* Apply HPF to stream if widget exists */
+		/* Apply EQ preset to stream if widget exists */
 		{
 			struct sst_widget *hpf_w;
 
 			hpf_w = sst_topology_find_widget(sc, "HPF1.0");
-			if (hpf_w != NULL && sc->pcm.hpf_cutoff > 0) {
+			if (hpf_w != NULL) {
 				hpf_w->stream_id = ch->stream_id;
-				sst_topology_set_widget_hpf(sc, hpf_w,
-				    sc->pcm.hpf_cutoff);
+				sst_topology_set_widget_eq_preset(sc, hpf_w,
+				    sc->pcm.eq_preset);
 			}
 		}
 
@@ -1271,16 +1282,6 @@ sst_percent_to_q131(unsigned int pct)
 }
 
 /*
- * HPF cutoff frequencies for BASS mixer control.
- * Index 0 = bypass, indices 1-8 = 80..300 Hz presets.
- * Mixer value 0 = off, 1-100 mapped across presets via:
- *   idx = 1 + (val - 1) * 8 / 100
- */
-static const uint32_t sst_hpf_cutoffs[] = {
-	0, 80, 100, 120, 150, 180, 200, 250, 300
-};
-
-/*
  * Mixer methods
  */
 static int
@@ -1302,8 +1303,8 @@ sst_mixer_init(struct snd_mixer *m)
 	sc->pcm.vol_right = 100;
 	sc->pcm.mute = 0;
 
-	/* Default HPF: 150 Hz (mixer bass = 50) */
-	sc->pcm.hpf_cutoff = 150;
+	/* Default EQ: stock speaker (HPF 150Hz) */
+	sc->pcm.eq_preset = SST_EQ_PRESET_STOCK_SPEAKER;
 
 	/* Default limiter: -6 dBFS (mixer treble = 60, preset index 5) */
 	sc->pcm.limiter_threshold = 5;
@@ -1364,28 +1365,26 @@ sst_mixer_set(struct snd_mixer *m, unsigned dev, unsigned left, unsigned right)
 
 	case SOUND_MIXER_BASS: {
 		struct sst_widget *hpf_w;
-		uint32_t cutoff;
-		int idx;
+		enum sst_eq_preset_id preset;
 
 		/*
-		 * Map mixer value (0-100) to HPF cutoff preset.
-		 * 0 = HPF off (bypass), 1-100 = 80..300 Hz.
-		 * Only the left channel value is used (mono control).
+		 * Map mixer value (0-100) to EQ preset:
+		 *   0     = flat (bypass)
+		 *   1-50  = stock_speaker (HPF 150Hz)
+		 *   51-100 = mod_speaker (HPF 100Hz, warmer)
 		 */
-		if (left == 0) {
-			idx = 0;
-		} else {
-			idx = 1 + (left - 1) * 8 / 100;
-			if (idx > 8)
-				idx = 8;
-		}
-		cutoff = sst_hpf_cutoffs[idx];
-		sc->pcm.hpf_cutoff = cutoff;
+		if (left == 0)
+			preset = SST_EQ_PRESET_FLAT;
+		else if (left <= 50)
+			preset = SST_EQ_PRESET_STOCK_SPEAKER;
+		else
+			preset = SST_EQ_PRESET_MOD_SPEAKER;
 
-		/* Update HPF widget if topology is loaded */
+		sc->pcm.eq_preset = preset;
+
 		hpf_w = sst_topology_find_widget(sc, "HPF1.0");
 		if (hpf_w != NULL)
-			sst_topology_set_widget_hpf(sc, hpf_w, cutoff);
+			sst_topology_set_widget_eq_preset(sc, hpf_w, preset);
 
 		break;
 	}

--- a/sst_pcm.h
+++ b/sst_pcm.h
@@ -14,6 +14,8 @@
 #include <sys/types.h>
 #include <sys/callout.h>
 
+#include "sst_topology.h"
+
 /*
  * PCM Channel Configuration
  *
@@ -126,8 +128,8 @@ struct sst_pcm {
 	int			vol_right;	/* Right volume (0-100) */
 	int			mute;		/* Mute state */
 
-	/* HPF control */
-	uint32_t		hpf_cutoff;	/* HPF cutoff in Hz, 0=bypass */
+	/* EQ preset control */
+	enum sst_eq_preset_id	eq_preset;	/* Active EQ preset */
 
 	/* Limiter control */
 	uint32_t		limiter_threshold; /* Preset index, 0=bypass */

--- a/sst_topology.h
+++ b/sst_topology.h
@@ -87,6 +87,21 @@ enum sst_module_type {
 };
 
 /*
+ * EQ Preset IDs
+ *
+ * Each preset is a single 2nd-order biquad defining one EQ profile.
+ * The catpt DSP supports only one biquad stage per stream (SET_BIQUAD
+ * IPC has no stage index), so presets combine HPF + tone shaping into
+ * a single filter section.
+ */
+enum sst_eq_preset_id {
+	SST_EQ_PRESET_FLAT = 0,	/* Bypass (passthrough) */
+	SST_EQ_PRESET_STOCK_SPEAKER,	/* HPF 150Hz (stock speaker protection) */
+	SST_EQ_PRESET_MOD_SPEAKER,	/* HPF 100Hz (warmer, less bass cut) */
+	SST_EQ_PRESET_MAX
+};
+
+/*
  * Widget Definition
  */
 struct sst_widget {
@@ -110,8 +125,8 @@ struct sst_widget {
 	int32_t			volume;		/* -64dB to +20dB in 0.5dB steps */
 	bool			mute;
 
-	/* HPF control (for EFFECT/HPF) */
-	uint32_t		hpf_cutoff;	/* HPF cutoff in Hz, 0=bypass */
+	/* EQ preset (for EFFECT/HPF) */
+	enum sst_eq_preset_id	eq_preset;	/* Active EQ preset */
 
 	/* Limiter control (for EFFECT/LIMITER) */
 	uint32_t		limiter_threshold; /* Preset index, 0=bypass */
@@ -243,8 +258,9 @@ struct sst_widget *sst_topology_find_widget(struct sst_softc *sc,
 					    const char *name);
 int	sst_topology_set_widget_volume(struct sst_softc *sc,
 				       struct sst_widget *w, int32_t volume);
-int	sst_topology_set_widget_hpf(struct sst_softc *sc,
-				    struct sst_widget *w, uint32_t cutoff);
+int	sst_topology_set_widget_eq_preset(struct sst_softc *sc,
+					  struct sst_widget *w,
+					  enum sst_eq_preset_id preset);
 int	sst_topology_set_widget_limiter(struct sst_softc *sc,
 					struct sst_widget *w,
 					uint32_t threshold_idx);


### PR DESCRIPTION
## Summary

Closes #4.

- Replace frequency-based HPF cutoff selection (`sst_hpf_cutoffs[]`, `sst_hpf_biquad[]`) with named EQ presets (`sst_eq_presets[]`)
- Add `enum sst_eq_preset_id` with three presets: `FLAT` (bypass), `STOCK_SPEAKER` (HPF 150Hz), `MOD_SPEAKER` (HPF 100Hz, warmer)
- BASS mixer maps 0=flat, 1-50=stock_speaker, 51-100=mod_speaker for simple preset switching
- EQ preset persists across suspend/resume and DSP stall recovery

### Hardware constraint

The catpt DSP supports only **one 2nd-order biquad stage per stream** — the `SET_BIQUAD` IPC has no stage index in header bits 15:12. Multi-band parametric EQ is not possible, so this implements named presets where each is a single biquad filter profile.

### Files changed

| File | Change |
|------|--------|
| `sst_topology.h` | Add `enum sst_eq_preset_id`, `eq_preset` field in widget, new `sst_topology_set_widget_eq_preset()` API |
| `sst_topology.c` | Add `sst_eq_presets[]` table, implement `sst_topology_set_widget_eq_preset()`, remove old `sst_hpf_biquad[]` + `sst_topology_set_widget_hpf()` |
| `sst_pcm.h` | Replace `hpf_cutoff` with `eq_preset` in `struct sst_pcm` |
| `sst_pcm.c` | Rewrite BASS mixer handler, update PCMTRIG_START/resume/stall recovery, remove `sst_hpf_cutoffs[]` |

## Test plan

- [ ] `make clean && make` — compiles with no new warnings
- [ ] `kldload ./acpi_intel_sst.ko` + play audio — stock_speaker preset active by default
- [ ] `mixer bass 0` — flat bypass (more bass)
- [ ] `mixer bass 25` — stock_speaker (HPF 150Hz)
- [ ] `mixer bass 75` — mod_speaker (HPF 100Hz, warmer)
- [ ] Suspend/resume (`acpiconf -s 3`) — EQ preset persists
- [ ] Stall recovery — preset restored after stream re-allocation