### PR TITLE
feat: add sysctl interface for EQ preset switching

### DIFF
--- a/acpi_intel_sst.c
+++ b/acpi_intel_sst.c
@@ -2901,6 +2901,9 @@ dsp_init:
 	}
 	error = 0;
 
+	/* EQ preset sysctl */
+	sst_topology_sysctl_init(sc);
+
 	/* RT286 codec initialization and output enable */
 	if (sst_codec_init(sc) == 0) {
 		sst_codec_enable_speaker(sc);
@@ -3162,6 +3165,9 @@ sst_pci_attach(device_t dev)
 			sst_jack_enable(sc);
 		}
 		error = 0;
+
+		/* EQ preset sysctl */
+		sst_topology_sysctl_init(sc);
 
 		/* RT286 codec initialization and output enable */
 		if (sst_codec_init(sc) == 0) {

--- a/sst_topology.h
+++ b/sst_topology.h
@@ -273,4 +273,7 @@ int	sst_topology_disconnect_route(struct sst_softc *sc, struct sst_route *r);
 struct sst_pipeline *sst_topology_get_pipeline(struct sst_softc *sc,
 					       int dir, int stream_num);
 
+/* Sysctl interface */
+int	sst_topology_sysctl_init(struct sst_softc *sc);
+
 #endif /* _SST_TOPOLOGY_H_ */


### PR DESCRIPTION
## Summary
- Adds `dev.acpi_intel_sst.N.eq_preset` sysctl node (RW) for direct EQ preset control (#8)
- Sysctl handler validates range, updates `sc->pcm.eq_preset`, and applies biquad coefficients to the HPF widget
- Registration called from both ACPI and PCI attach paths, following the existing `sst_jack_sysctl_init()` pattern

## Test plan
- [ ] `make clean && make` — compiles with no new warnings
- [ ] `sysctl dev.acpi_intel_sst.0.eq_preset` — reads current preset (default 1)
- [ ] `sysctl dev.acpi_intel_sst.0.eq_preset=0` — switch to flat
- [ ] `sysctl dev.acpi_intel_sst.0.eq_preset=2` — switch to mod_speaker
- [ ] `sysctl dev.acpi_intel_sst.0.eq_preset=99` — returns EINVAL

Closes #8