### PR TITLE
feat: gain staging with headroom policy and EQ gain budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ mixer vol 80 && play -n synth 3 sine 440
 | EQ presets (speaker protection) | :white_check_mark: |
 | Peak limiter (speaker protection) | :white_check_mark: |
 | DSP stage capability detection | :white_check_mark: |
+| Gain staging / headroom (-3dBFS) | :white_check_mark: |
 | Dynamic pipeline topology | :white_check_mark: |
 | DSP stream stall recovery | :white_check_mark: |
 | Suspend/resume (S3) | :white_check_mark: |

--- a/sst_topology.h
+++ b/sst_topology.h
@@ -101,6 +101,10 @@ enum sst_eq_preset_id {
 	SST_EQ_PRESET_MAX
 };
 
+/* Gain staging: global headroom policy */
+#define SST_HEADROOM_DB		3
+#define SST_HEADROOM_HALF_DB	6	/* in 0.5dB step units */
+
 /*
  * Widget Definition
  */


### PR DESCRIPTION
## Summary
- Add 3dB headroom policy (`SST_HEADROOM_DB`) to prevent digital clipping across the playback pipeline
- Scale mixer percent-to-Q1.31 by a headroom factor, shifting volume ceiling from -1dBFS to -3dBFS
- Add `peak_gain_db` field to EQ presets for gain budget tracking
- Enforce dynamic volume ceiling in `sst_topology_set_widget_volume()` that accounts for active EQ peak gain
- Auto-clamp PGA volume when switching to an EQ preset with positive peak gain

## Test plan
- [ ] Verify volume at 100% outputs at -3dBFS (not -1dBFS)
- [ ] Verify EQ preset changes with peak_gain_db=0 do not affect volume ceiling
- [ ] Verify future EQ presets with positive peak_gain_db correctly lower volume ceiling
- [ ] Verify capture path PGA (PGA2.0) is unaffected by playback HPF headroom